### PR TITLE
Enhance dashboard filters and search experience

### DIFF
--- a/src/components/ToolCard.tsx
+++ b/src/components/ToolCard.tsx
@@ -1,7 +1,13 @@
 import { Link } from "react-router-dom";
+import type { ReactNode } from "react";
 import type { ToolCard } from "../data/tools";
 
-export function ToolCardItem({ card }: { card: ToolCard }) {
+type ToolCardProps = {
+  card: ToolCard;
+  highlight?: string;
+};
+
+export function ToolCardItem({ card, highlight }: ToolCardProps) {
   return (
     <Link
       key={card.title}
@@ -14,8 +20,8 @@ export function ToolCardItem({ card }: { card: ToolCard }) {
           className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs uppercase tracking-[0.3em] text-cyan-100"
           dangerouslySetInnerHTML={{ __html: card.badge }}
         />
-        <h3 className="text-xl font-semibold text-white">{card.title}</h3>
-        <p className="text-sm text-slate-200/80">{card.description}</p>
+        <h3 className="text-xl font-semibold text-white">{highlightText(card.title, highlight)}</h3>
+        <p className="text-sm text-slate-200/80">{highlightText(card.description, highlight)}</p>
         <p className="text-xs uppercase tracking-[0.4em] text-cyan-200/70">{card.cta}</p>
         <div className="flex flex-wrap gap-2 pt-1 text-[10px] uppercase tracking-[0.3em] text-cyan-200/70">
           {card.tags.slice(0, 4).map((tag) => (
@@ -27,5 +33,29 @@ export function ToolCardItem({ card }: { card: ToolCard }) {
       </div>
     </Link>
   );
+}
+
+function highlightText(text: string, query?: string): ReactNode {
+  if (!query?.trim()) return text;
+
+  const escaped = escapeRegExp(query.trim());
+  if (!escaped) return text;
+
+  const regex = new RegExp(`(${escaped})`, "gi");
+  const segments = text.split(regex);
+
+  return segments.map((segment, index) =>
+    index % 2 === 1 ? (
+      <mark key={`${segment}-${index}`} className="rounded bg-cyan-500/40 px-0.5 text-slate-950">
+        {segment}
+      </mark>
+    ) : (
+      <span key={`${segment}-${index}`}>{segment}</span>
+    ),
+  );
+}
+
+function escapeRegExp(input: string) {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 


### PR DESCRIPTION
## Summary
- add category and tag filters plus sort controls to the dashboard landing page
- highlight matched query terms in tool cards for clearer search feedback
- expose filter counts with a quick clear action to reset discovery

## Testing
- npm run build *(fails: pdf-lib dependency missing)*

------
https://chatgpt.com/codex/tasks/task_e_68e438ba60b4832a94ae2a02b3e6df62